### PR TITLE
fix: add missing dependencies for semantic-release conventional commits

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -32,7 +32,7 @@ jobs:
     
     - name: Install semantic-release
       run: |
-        npm install -g semantic-release @semantic-release/github
+        npm install -g semantic-release @semantic-release/github @semantic-release/commit-analyzer @semantic-release/release-notes-generator conventional-changelog-conventionalcommits
     
     - name: Set up Go
       uses: actions/setup-go@v4

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -4,7 +4,7 @@
     [
       "@semantic-release/commit-analyzer",
       {
-        "preset": "conventionalcommits",
+        "preset": "angular",
         "releaseRules": [
           {"type": "feat", "release": "minor"},
           {"type": "fix", "release": "patch"},
@@ -24,22 +24,7 @@
     [
       "@semantic-release/release-notes-generator",
       {
-        "preset": "conventionalcommits",
-        "presetConfig": {
-          "types": [
-            {"type": "feat", "section": "🚀 Features"},
-            {"type": "fix", "section": "🐛 Bug Fixes"},
-            {"type": "perf", "section": "⚡ Performance Improvements"},
-            {"type": "revert", "section": "⏪ Reverts"},
-            {"type": "refactor", "section": "📦 Code Refactoring"},
-            {"type": "docs", "section": "📚 Documentation", "hidden": false},
-            {"type": "style", "section": "💎 Styles", "hidden": true},
-            {"type": "chore", "section": "🔧 Miscellaneous Chores", "hidden": true},
-            {"type": "test", "section": "🧪 Tests", "hidden": true},
-            {"type": "build", "section": "🛠 Build System", "hidden": true},
-            {"type": "ci", "section": "⚙️ Continuous Integration", "hidden": true}
-          ]
-        }
+        "preset": "angular"
       }
     ],
     [


### PR DESCRIPTION
- Install required npm packages: @semantic-release/commit-analyzer, @semantic-release/release-notes-generator, conventional-changelog-conventionalcommits
- Change preset from conventionalcommits to angular for better compatibility
- Resolve MODULE_NOT_FOUND error for conventional-changelog-conventionalcommits